### PR TITLE
Initialization hook with SNS & SQS configuration on Localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ aws --endpoint http://localhost:4566 --profile localstack sqs send-message --que
 aws --endpoint http://localhost:4566 --profile localstack sqs receive-message --queue-url http://localhost:4566/000000000000/pedidoRecebido
 ```
 
+Comandos para a configuração do SNS e do SQS:
+```bash
+aws --endpoint http://localhost:4566 --profile localstack sns create-topic --name ms-pedido
+aws --endpoint http://localhost:4566 --profile localstack sqs create-queue --queue-name ms-pagamento-evento-pedido-recebido
+aws --endpoint http://localhost:4566 --profile localstack sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pedido --protocol sqs --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pedido-recebido --attributes '{ \"RawMessageDelivery\": \"true\" }'
+aws --endpoint http://localhost:4566 --profile localstack sqs create-queue --queue-name ms-producao-evento-pedido-recebido
+aws --endpoint http://localhost:4566 --profile localstack sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pedido --protocol sqs --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-producao-evento-pedido-recebido --attributes '{ \"RawMessageDelivery\": \"true\" }'
+```
+
 Referências
 
 - https://www.baeldung.com/java-spring-cloud-aws-v3-intro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,11 @@ services:
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      - SERVICES=sqs,sns,dynamodb
+      - SQS_ENDPOINT_STRATEGY=off
+      - LOCALSTACK_HOST=localhost:4566
       - DEBUG=${DEBUG:-0}
     volumes:
+      - "./localstack:/etc/localstack/init/ready.d:ro"
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/init-aws.sh
+++ b/localstack/init-aws.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -v
+
+awslocal sns create-topic \
+  --name ms-pedido
+
+awslocal sqs create-queue \
+  --queue-name ms-pagamento-evento-pedido-recebido
+
+awslocal sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pedido \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pedido-recebido \
+  --attributes '{ "RawMessageDelivery": "true" }'
+
+awslocal sqs create-queue \
+  --queue-name ms-producao-evento-pedido-recebido
+
+awslocal sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pedido \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-producao-evento-pedido-recebido \
+  --attributes '{ "RawMessageDelivery": "true" }'


### PR DESCRIPTION
This pull request primarily focuses on the configuration of SNS and SQS services in the local AWS setup. The changes include the addition of commands for the SNS and SQS setup in the `README.md` file, modification of the `docker-compose.yml` file to include new environment variables and volume mapping for the localstack setup, and the creation of a new bash script `init-aws.sh` to automate the setup of AWS services.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R40): Added commands for setting up SNS and SQS services in the local AWS environment. This includes creating topics, queues, and subscriptions.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R12-R17): Added new environment variables `SERVICES`, `SQS_ENDPOINT_STRATEGY`, and `LOCALSTACK_HOST` to the localstack service configuration. Also added a new volume mapping to load scripts during localstack initialization.

* [`localstack/init-aws.sh`](diffhunk://#diff-75f2bd3e10422803c8e7553aad876b0a373155e6b7362a10e8839e975b503913R1-R24): Created a new bash script to automate the setup of AWS services. This script uses the `awslocal` command to create SNS topics, SQS queues, and subscriptions.