### PR TITLE
Update init-aws.sh

### DIFF
--- a/localstack/init-aws.sh
+++ b/localstack/init-aws.sh
@@ -6,7 +6,11 @@ awslocal sns create-topic \
   --name ms-pedido
 
 awslocal sqs create-queue \
-  --queue-name ms-pagamento-evento-pedido-recebido
+  --queue-name ms-pagamento-evento-pedido-recebido-dlq
+
+awslocal sqs create-queue \
+  --queue-name ms-pagamento-evento-pedido-recebido \
+  --attributes '{ "RedrivePolicy": "{\"deadLetterTargetArn\": \"arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pedido-recebido-dlq\", \"maxReceiveCount\": \"3\" }" }'
 
 awslocal sns subscribe \
   --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pedido \
@@ -15,10 +19,45 @@ awslocal sns subscribe \
   --attributes '{ "RawMessageDelivery": "true" }'
 
 awslocal sqs create-queue \
-  --queue-name ms-producao-evento-pedido-recebido
+  --queue-name ms-producao-evento-pedido-recebido-dlq
+
+awslocal sqs create-queue \
+  --queue-name ms-producao-evento-pedido-recebido \
+  --attributes '{ "RedrivePolicy": "{\"deadLetterTargetArn\": \"arn:aws:sqs:us-east-1:000000000000:ms-producao-evento-pedido-recebido-dlq\", \"maxReceiveCount\": \"3\" }" }'
 
 awslocal sns subscribe \
   --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pedido \
   --protocol sqs \
   --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-producao-evento-pedido-recebido \
   --attributes '{ "RawMessageDelivery": "true" }'
+
+############################################
+
+awslocal sns create-topic \
+  --name ms-pagamento
+
+awslocal sqs create-queue \
+  --queue-name ms-pagamento-evento-pagamento-aprovado-dlq
+
+awslocal sqs create-queue \
+  --queue-name ms-pagamento-evento-pagamento-aprovado \
+  --attributes '{ "RedrivePolicy": "{\"deadLetterTargetArn\": \"arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pagamento-aprovado-dlq\", \"maxReceiveCount\": \"3\" }" }'
+
+awslocal sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pagamento \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pagamento-aprovado \
+  --attributes '{ "RawMessageDelivery": "true", "FilterPolicy": "{\"event-type\": [\"aprovado\"]}" }'
+
+awslocal sqs create-queue \
+  --queue-name ms-pagamento-evento-pagamento-recusado-dlq
+
+awslocal sqs create-queue \
+  --queue-name ms-pagamento-evento-pagamento-recusado \
+  --attributes '{ "RedrivePolicy": "{\"deadLetterTargetArn\": \"arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pagamento-recusado-dlq\", \"maxReceiveCount\": \"3\" }" }'
+
+awslocal sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:ms-pagamento \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:us-east-1:000000000000:ms-pagamento-evento-pagamento-recusado \
+  --attributes '{ "RawMessageDelivery": "true", "FilterPolicy": "{\"event-type\": [\"recusado\"]}" }'


### PR DESCRIPTION
This pull request focuses on the `localstack/init-aws.sh` file, where changes have been made to improve the handling of AWS SNS and SQS services. The changes involve creating dead-letter queues (DLQs) for specific SQS queues and modifying the attributes of these queues to include a `RedrivePolicy`. Additionally, a new SNS topic `ms-pagamento` has been created, along with corresponding SQS queues and subscriptions.

* `localstack/init-aws.sh`: 
    * Changed the `awslocal sqs create-queue` command to create a DLQ named `ms-pagamento-evento-pedido-recebido-dlq` and modified the original queue `ms-pagamento-evento-pedido-recebido` to include a `RedrivePolicy` pointing to the new DLQ.
    * Similar changes were made for the `ms-producao-evento-pedido-recebido` queue, creating a DLQ and modifying the original queue to include a `RedrivePolicy`.
    * Created a new SNS topic `ms-pagamento` and corresponding SQS queues `ms-pagamento-evento-pagamento-aprovado` and `ms-pagamento-evento-pagamento-recusado`, each with their own DLQ and `RedrivePolicy`. Subscriptions to the `ms-pagamento` topic were also created for these queues, with `RawMessageDelivery` set to `true` and a `FilterPolicy` to filter events.